### PR TITLE
Websocket notification correction

### DIFF
--- a/templates/lnurldevice/index.html
+++ b/templates/lnurldevice/index.html
@@ -712,10 +712,10 @@
         if ('WebSocket' in window) {
           self = this
           var ws = new WebSocket(websocketUrl)
-          self.updateWsMessage('Websocket connected')
+          self.updateWsMessage('Websocket established')
           ws.onmessage = function (evt) {
             var received_msg = evt.data
-            self.updateWsMessage('Message recieved: ' + received_msg)
+            self.updateWsMessage('Message broadcasted: ' + received_msg)
           }
           ws.onclose = function () {
             self.updateWsMessage('Connection closed')


### PR DESCRIPTION
The messages in the QR code pop up window are slightly misleading as they only show the status of the LNbits server (or the websocket connection to the web page) and not the real websocket connection to the ESP32. 

This PR changes two display texts:

"Websocket connected" -> "Websocket established"

"Message received: ..." -> "Message broadcasted: .."