### PR TITLE
Add description to switch devices

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "repos": [
     {
       "id": "lnurldevice",
-      "organisation": "lnbits",
+      "organisation": "casavinteum",
       "repository": "lnurldevice"
     }
   ]

--- a/migrations.py
+++ b/migrations.py
@@ -219,3 +219,8 @@ async def m006_redux(db):
     await db.execute(
         "ALTER TABLE lnurldevice.lnurldevice RENAME COLUMN switches TO extra"
     )
+
+async def m007_redux(db):
+    await db.execute(
+        "ALTER TABLE lnurldevice.lnurldevice ADD COLUMN description TEXT;"
+    )

--- a/models.py
+++ b/models.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Json
 
 
 class LnurldeviceExtra(BaseModel):
+    description: str = ""
     amount: float = 0.0
     duration: int = 0
     pin: int = 0

--- a/templates/lnurldevice/index.html
+++ b/templates/lnurldevice/index.html
@@ -423,6 +423,15 @@
                 ></q-input>
               </div>
               <div class="col q-ml-md">
+                <q-input
+                  filled
+                  dense
+                  v-model.trim="_switch.description"
+                  type="text"
+                  label="Description"
+                ></q-input>
+              </div>
+              <div class="col q-ml-md">
                 <q-checkbox
                   v-model="_switch.variable"
                   color="primary"


### PR DESCRIPTION
This way we can have a backend customizable field instead of hardcoding names/labels for the switches.

We are using this in our Draft beer dispenser. Each button on the screen, is a different switch on our lnbits instance. You can check the code here: https://github.com/CasaVinteUm/BitChopp